### PR TITLE
Upgrade Jakarta websocket from 2.0.0 to 2.1.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -18,7 +18,7 @@ ext.versions = [
 	'guava_orbit': '30.1.0.v20210127-2300',
 	'gson': '[2.9.0,2.10)',
 	'gson_orbit': '2.9.0.v20220704-0629',
-	'websocket_jakarta': '2.0.0',
+	'websocket_jakarta': '2.1.0',
 	'websocket': '1.0',
 	'junit': '4.12'
 ]


### PR DESCRIPTION
it allows to be compatible with latest Tyrus RFC implementation 2.1.0 see https://jakarta.ee/specifications/websocket/2.1/ and https://github.com/eclipse-ee4j/tyrus/releases/tag/2.1.0
Note:
- wasn't able to build the project (do not have anymore a working gradle environment locally and not familiar with Gradle) so wasn't able to try everything locally
- i was able to force usage of this newer websocket api in my own project and my tests using Tyrus 2.1 are passing fine, see https://github.com/camel-tooling/camel-language-server/pull/799