### PR TITLE
Pass more informative `Throwable` from handler invocations

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -64,7 +64,7 @@ public class GenericEndpoint implements Endpoint {
 					Object[] arguments = this.getArguments(method, arg);
 					return (CompletableFuture<Object>) method.invoke(current, arguments);
 				} catch (InvocationTargetException | IllegalAccessException e) {
-					throw new RuntimeException(e);
+					throw new RuntimeException(e.getCause());
 				}
 			};
 			if (methodHandlers.put(methodInfo.name, handler) != null) {

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -63,8 +63,10 @@ public class GenericEndpoint implements Endpoint {
 					Method method = methodInfo.method;
 					Object[] arguments = this.getArguments(method, arg);
 					return (CompletableFuture<Object>) method.invoke(current, arguments);
-				} catch (InvocationTargetException | IllegalAccessException e) {
+				} catch (InvocationTargetException e) {
 					throw new RuntimeException(e.getCause());
+				} catch (IllegalAccessException e) {
+					throw new RuntimeException(e);
 				}
 			};
 			if (methodHandlers.put(methodInfo.name, handler) != null) {


### PR DESCRIPTION
[RemoteEndpoint.java](https://github.com/eclipse/lsp4j/blob/5605ca82252833777dbef82ca13a403dbfb9d906/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java#L50) - as it stands, a `Throwable`, deriving from an `InvocationTargetException` from `GenericEndpoint.recursiveFindRpcMethods`, passed into `RemoteEndpoint.exceptionHandler` will not be handled as an `InvocationTargetException`. With this change, a custom `exceptionHandler` will at least be able to use the `Throwable` message that was thrown from the invoked handler.

For example, suppose I have a debug server with a RPC method `Foo` within which an `Exception` is thrown with message `custom string`.  Once `Foo` is invoked and throws an `Exception`, `exceptionHandler` will obtain a `RuntimeException` (from `recursiveFindRpcMethods`) with little connection to the thrown `Exception` - AFAIU, the custom message can only be obtained by parsing the stack trace which may be cumbersome. This change will allow a custom `exceptionHandler` to easily read from `Throwable.message` instead.