### PR TITLE
Avoid use of absolute path where BND can't handle it

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17 ☕
+    - name: Set up JDK 11 ☕
       uses: actions/setup-java@v3
       with:
         java-version: 11

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,11 @@ on: [ pull_request, push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11 ☕

--- a/gradle/manifest-gen.gradle
+++ b/gradle/manifest-gen.gradle
@@ -23,7 +23,7 @@ jar.bnd (
 	'Bundle-Vendor': 'Eclipse LSP4J',
 	'Bundle-RequiredExecutionEnvironment': 'JavaSE-11',
 	"-exportcontents": "org.eclipse.lsp4j.*",
-	"-savemanifest": "$buildDir/tmp/bnd/MANIFEST.MF",
+	"-savemanifest": "build/tmp/bnd/MANIFEST.MF",
 )
 
 //------------------------------------------------------


### PR DESCRIPTION
BND when calculating the full path to savemanifest runs within the current dir being the root of the project. Making this change (`$buildDir` -> `build`) does not change the output but does make it work on Windows.