### PR TITLE
Using internals which may not be visible #738

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/MessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/MessageTypeAdapter.java
@@ -43,7 +43,6 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.Primitives;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -456,8 +455,8 @@ public class MessageTypeAdapter extends TypeAdapter<Message> {
 	protected void handleParameter(JsonWriter out, Object params, String method) {
 		boolean isSingleArray = (getParameterTypes(method).length == 1 && Collection.class.isInstance(params)
 				|| params.getClass().isArray());
-		boolean needsWrap = isSingleArray || params instanceof String || Primitives.isPrimitive(getClass())
-				|| Primitives.isWrapperType(params.getClass());
+		boolean needsWrap = isSingleArray || params instanceof String || isWrapperType(params.getClass())
+				|| isPrimitive(getClass());
 		if (needsWrap) {
 			gson.toJson(List.of(params), List.class, out);
 		} else {
@@ -484,4 +483,22 @@ public class MessageTypeAdapter extends TypeAdapter<Message> {
 		out.setSerializeNulls(previousSerializeNulls);
 	}
 	
+	/**
+	 * Returns true if this type is a primitive.
+	 */
+	private static boolean isPrimitive(Type type) {
+		return type instanceof Class<?> && ((Class<?>) type).isPrimitive();
+	}
+
+	/**
+	 * Returns {@code true} if {@code type} is one of the nine primitive-wrapper
+	 * types, such as {@link Integer}.
+	 *
+	 * @see Class#isPrimitive
+	 */
+	private static boolean isWrapperType(Type type) {
+		return type == Integer.class || type == Float.class || type == Byte.class || type == Double.class
+				|| type == Long.class || type == Character.class || type == Boolean.class || type == Short.class
+				|| type == Void.class;
+	}
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
@@ -787,8 +787,34 @@ public class MessageJsonHandlerTest {
 
 	@Test
 	public void testWrapPrimitive_JsonRpc2_0() {
-		MessageJsonHandler handler = createSimpleRequestHandler(String.class, String.class);
+		MessageJsonHandler handler = createSimpleRequestHandler(Boolean.class, int.class);
 
+		var request = new RequestMessage();
+		request.setId(1);
+		request.setMethod(handler.getMethodProvider().resolveMethod(null));
+		request.setParams(3);
+		
+		// check primitive was wrapped into array
+		assertEquals("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"testMethod\",\"params\":[3]}", handler.serialize(request));
+	}
+	
+	@Test
+	public void testWrapPrimitiveWrapper_JsonRpc2_0() {
+		MessageJsonHandler handler = createSimpleRequestHandler(Boolean.class, Character.class);
+		
+		var request = new RequestMessage();
+		request.setId(1);
+		request.setMethod(handler.getMethodProvider().resolveMethod(null));
+		request.setParams('X');
+		
+		// check primitive was wrapped into array
+		assertEquals("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"testMethod\",\"params\":[\"X\"]}", handler.serialize(request));
+	}
+
+	@Test
+	public void testWrapStringWrapper_JsonRpc2_0() {
+		MessageJsonHandler handler = createSimpleRequestHandler(Boolean.class, String.class);
+		
 		var request = new RequestMessage();
 		request.setId(1);
 		request.setMethod(handler.getMethodProvider().resolveMethod(null));
@@ -798,6 +824,7 @@ public class MessageJsonHandlerTest {
 		assertEquals("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"testMethod\",\"params\":[\"param\"]}", handler.serialize(request));
 	}
 	
+
 	@Test
 	public void testUnwrapPrimitive_JsonRpc2_0() {
 		MessageJsonHandler handler = createSimpleRequestHandler(String.class, String.class);


### PR DESCRIPTION
Removes the `gson.internal.Primitives` import. Added some additional tests. 

See #738. 