### PR TITLE
fix: SemanticTokens.getData() returns null for instances via default ctor

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6184,6 +6184,7 @@ class SemanticTokens {
 	List<Integer> data
 
 	new() {
+		this.data = java.util.Collections.emptyList();
 	}
 
 	new(@NonNull List<Integer> data) {

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6184,7 +6184,7 @@ class SemanticTokens {
 	List<Integer> data
 
 	new() {
-		this.data = java.util.Collections.emptyList();
+		this.data = new ArrayList()
 	}
 
 	new(@NonNull List<Integer> data) {


### PR DESCRIPTION
`SemanticTokens#getData()` to returns `null` for instances created via default constructor which violates the `@NonNull` value API contract.

This PR is a root cause fix for https://github.com/eclipse/lsp4e/issues/861