### PR TITLE
Use/allow latest versions of dependencies for guava and jakarta.websocket

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,7 +14,7 @@ version = '0.22.0-SNAPSHOT'
 
 ext.versions = [
 	'xtend_lib': '2.32.0',
-	'guava': '[32.1.2,33)',
+	'guava': '[32.1.2,34)',
 	'gson': '[2.9.1,2.11)',
 	'websocket_jakarta': '2.0.0',
 	'websocket': '1.0',

--- a/releng/p2/category.xml
+++ b/releng/p2/category.xml
@@ -5,10 +5,12 @@
 	</feature>
 	<bundle id="com.google.gson" version="2.10.1.qualifier"/>
 	<bundle id="com.google.gson.source" version="2.10.1.qualifier"/>
-	<bundle id="com.google.guava" version="32.1.2.qualifier"/>
-	<bundle id="com.google.guava.source" version="32.1.2.qualifier"/>
-	<bundle id="jakarta.websocket" version="0.0.0"/>
-	<bundle id="jakarta.websocket.source" version="0.0.0"/>
+	<bundle id="com.google.guava" version="33.0.0.qualifier"/>
+	<bundle id="com.google.guava.source" version="33.0.0.qualifier"/>
+	<bundle id="jakarta.websocket-api" version="0.0.0"/>
+	<bundle id="jakarta.websocket-api.source" version="0.0.0"/>
+	<bundle id="jakarta.websocket-client-api" version="0.0.0"/>
+	<bundle id="jakarta.websocket-client-api.source" version="0.0.0"/>
 	<bundle id="javax.websocket" version="0.0.0"/>
 	<bundle id="javax.websocket.source" version="0.0.0"/>
    <category-def name="lsp4j" label="Lsp4j"/>

--- a/releng/releng-target/lsp4j.target.target
+++ b/releng/releng-target/lsp4j.target.target
@@ -3,13 +3,15 @@
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-03"/>
 			<unit id="com.google.gson" version="2.10.1"/>
 			<unit id="com.google.gson.source" version="2.10.1"/>
-			<unit id="com.google.guava" version="32.1.2.jre"/>
-			<unit id="com.google.guava.source" version="32.1.2.jre"/>
-			<unit id="jakarta.websocket" version="0.0.0"/>
-			<unit id="jakarta.websocket.source" version="0.0.0"/>
+			<unit id="com.google.guava" version="33.0.0.jre"/>
+			<unit id="com.google.guava.source" version="33.0.0.jre"/>
+			<unit id="jakarta.websocket-api" version="0.0.0"/>
+			<unit id="jakarta.websocket-api.source" version="0.0.0"/>
+			<unit id="jakarta.websocket-client-api" version="0.0.0"/>
+			<unit id="jakarta.websocket-client-api.source" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-03"/>


### PR DESCRIPTION
A new version of Guava has been released (33) that LSP4J works with and websocket is now published in a "better" way (direct from maven) so we republish that version now.

Consumers shouldn't need to change their dependencies as the lower bounds are unchanged.

This applies the changes in #785 and subsequent commits to main branch.