### PR TITLE
fix javadoc warning

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6683,7 +6683,7 @@ class DocumentSymbol {
  * Deprecated Use {@link DocumentSymbol} or {@link WorkspaceSymbol} instead if supported.
  *
  * This class is deprecated in the LSP specification. It is not annotated with Deprecated
- * annotation because the {@link org.eclipse.lsp4j.services.TextDocumentService.documentSymbol(DocumentSymbolParams)}
+ * annotation because the {@link org.eclipse.lsp4j.services.TextDocumentService#documentSymbol(DocumentSymbolParams)}
  * method requires it and causes deprecated warning in the code of all users of that API.
  */
 @JsonRpcData


### PR DESCRIPTION
This pulls out the commit by @cdietrich from https://github.com/eclipse-lsp4j/lsp4j/pull/781