### PR TITLE
Supply a Preconditions in common location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Breaking API changes:
   * The name field in WorkspaceFolder is no longer optional according to the specification.
     * See [#741](https://github.com/eclipse-lsp4j/lsp4j/issues/741) for detailed discussion.
   * The LSP4J generator when applied to `@JsonRpcData` annotated classes generates a dependency on package `org.eclipse.lsp4j.jsonrpc.util` in the `org.eclipse.lsp4j.jsonrpc` bundle to provide an implementation of `ToStringBuilder`.
-    * This removes the implied requirement in LSP4J 0.21.0 that there is a class called `ToStringBuilder` in a sub-package called `util`.
-    * This also removes the duplicated class `ToStringBuilder` in packages `org.eclipse.lsp4j.debug.util` and `org.eclipse.lsp4j.util`.
+    * This removes the implied requirement in LSP4J 0.21.0 that there is a class called `ToStringBuilder` and `Preconditions` in a sub-package called `util`.
+    * This also removes the duplicated class `ToStringBuilder` and `Preconditions` in packages `org.eclipse.lsp4j.debug.util` and `org.eclipse.lsp4j.util`.
     * See [#742](https://github.com/eclipse-lsp4j/lsp4j/issues/742) for detailed discussion.
 
 Nightly japicmp report: <https://download.eclipse.org/lsp4j/builds/main/japicmp-report/>

--- a/documentation/jsonrpc.md
+++ b/documentation/jsonrpc.md
@@ -201,12 +201,7 @@ public class HelloParam {
 The generation may generate dependencies on some additional classes.
 Refer to the following sub-sections for details.
 
-### `ToStringBuilder` and other dependent classes
+### `ToStringBuilder`, `Preconditions` and other dependent classes
 
-When using the generator the generated code may refer to `ToStringBuilder` and other classes in the `org.eclipse.lsp4j.jsonrpc` bundle.
+When using the generator the generated code may refer to `ToStringBuilder` and `Preconditions` and other classes in the `org.eclipse.lsp4j.jsonrpc` bundle.
 Ensure that there is a runtime dependency on the `org.eclipse.lsp4j.jsonrpc` in your project.
-
-### `Preconditions` class
-
-When using LSP4J's `@NonNull` annotations a class called `Preconditions` is needed with the method `checkNotNull` in a sub-package called `util` to check null annotations at runtime.
-For an example class refer to the versions provided in LSP4J ([link](https://github.com/eclipse-lsp4j/lsp4j/blob/main/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Preconditions.java)).

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/util/Preconditions.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/util/Preconditions.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2019 TypeFox and others.
+ * Copyright (c) 2019, 2024 TypeFox and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,18 +17,11 @@ package org.eclipse.lsp4j.debug.util;
 public final class Preconditions {
 	
 	private Preconditions() {}
-	
-	private static boolean nullChecks = true;
-	
-	public static void enableNullChecks(boolean enable) {
-		Preconditions.nullChecks = enable;
-	}
-	
-	public static <T> T checkNotNull(T object, String propertyName) {
-		if (nullChecks && object == null) {
-			throw new IllegalArgumentException("Property must not be null: " + propertyName);
-		}
-		return object;
-	}
 
+	/**
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.util.Preconditions#enableNullChecks(boolean)} directly.
+	 */
+	public static void enableNullChecks(boolean enable) {
+		org.eclipse.lsp4j.jsonrpc.util.Preconditions.enableNullChecks(enable);
+	}
 }

--- a/org.eclipse.lsp4j.generator/src/main/java/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.xtend
+++ b/org.eclipse.lsp4j.generator/src/main/java/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.xtend
@@ -172,10 +172,7 @@ class JsonRpcDataProcessor extends AbstractClassProcessor {
 	}
 	
 	private def getPreconditionsUtil(Type type, extension TransformationContext context) {
-		if (type.qualifiedName.startsWith('org.eclipse.lsp4j.debug'))
-			newTypeReference('org.eclipse.lsp4j.debug.util.Preconditions')
-		else
-			newTypeReference('org.eclipse.lsp4j.util.Preconditions')
+		newTypeReference('org.eclipse.lsp4j.jsonrpc.util.Preconditions')
 	}
 
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Preconditions.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Preconditions.java
@@ -1,27 +1,33 @@
 /******************************************************************************
  * Copyright (c) 2019, 2024 TypeFox and others.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0,
  * or the Eclipse Distribution License v. 1.0 which is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  ******************************************************************************/
-package org.eclipse.lsp4j.util;
+package org.eclipse.lsp4j.jsonrpc.util;
 
 /**
  * Utilities for checking method and constructor arguments.
  */
 public final class Preconditions {
-	
+
 	private Preconditions() {}
 
-	/**
-	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.util.Preconditions#enableNullChecks(boolean)} directly.
-	 */
+	private static boolean nullChecks = true;
+
 	public static void enableNullChecks(boolean enable) {
-		org.eclipse.lsp4j.jsonrpc.util.Preconditions.enableNullChecks(enable);
+		Preconditions.nullChecks = enable;
+	}
+
+	public static <T> T checkNotNull(T object, String propertyName) {
+		if (nullChecks && object == null) {
+			throw new NullPointerException("Property must not be null: " + propertyName);
+		}
+		return object;
 	}
 }


### PR DESCRIPTION
This change provides the Preconditions in an util package in the org.eclipse.lsp4j.jsonrpc bundle so that consumers of LSP4J do not need to copy Preconditions into their own source code.

Related to #742