### PR TITLE
Deprecate lsp4j.websocket in preparation for removal in the future.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Fixed issues: <https://github.com/eclipse-lsp4j/lsp4j/milestone/29?closed=1>
 
+  * The `org.eclipse.lsp4j.websocket` bundle has been deprecated in preparation for removal in the future.
+    * Please migrate to `org.eclipse.lsp4j.websocket.jakarta`
+    * The `org.eclipse.lsp4j.websocket` bundle is no longer included in the SDK feature nor published to Eclipse SimRel
+    * See [#647](https://github.com/eclipse-lsp4j/lsp4j/issues/647) for detailed discussion.
+
 Breaking API changes:
 
   * The Message class now has a new transient field, `jsonHandler`, to enable the `toString` implementation to properly format messages when custom type adapters are used.

--- a/org.eclipse.lsp4j.websocket/build.gradle
+++ b/org.eclipse.lsp4j.websocket/build.gradle
@@ -11,7 +11,7 @@
  ******************************************************************************/
 
 ext.title = 'LSP4J WebSocket'
-description = 'WebSocket support for LSP4J'
+description = 'WebSocket support for LSP4J (deprecated, please migrate to org.eclipse.lsp4j.websocket.jakarta)'
 
 dependencies {
 	api project(":org.eclipse.lsp4j.jsonrpc")

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketEndpoint.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketEndpoint.java
@@ -23,7 +23,9 @@ import org.eclipse.lsp4j.jsonrpc.Launcher;
  * WebSocket endpoint implementation that connects to a JSON-RPC service.
  *
  * @param <T> remote service interface type
+ * @deprecated Please migrate to org.eclipse.lsp4j.websocket.jakarta
  */
+@Deprecated(forRemoval = true)
 public abstract class WebSocketEndpoint<T> extends Endpoint {
 	
 	@Override

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketLauncherBuilder.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketLauncherBuilder.java
@@ -26,7 +26,9 @@ import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
  * JSON-RPC launcher builder for use in {@link WebSocketEndpoint}.
  *
  * @param <T> remote service interface type
+ * @deprecated Please migrate to org.eclipse.lsp4j.websocket.jakarta
  */
+@Deprecated(forRemoval = true)
 public class WebSocketLauncherBuilder<T> extends Launcher.Builder<T> {
 	
 	protected Session session;

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
@@ -27,7 +27,9 @@ import org.eclipse.lsp4j.jsonrpc.messages.Message;
 
 /**
  * Message consumer that sends messages via a WebSocket session.
+ * @deprecated Please migrate to org.eclipse.lsp4j.websocket.jakarta
  */
+@Deprecated(forRemoval = true)
 public class WebSocketMessageConsumer implements MessageConsumer {
 
 	private static final Logger LOG = Logger.getLogger(WebSocketMessageConsumer.class.getName());

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageHandler.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageHandler.java
@@ -21,7 +21,9 @@ import org.eclipse.lsp4j.jsonrpc.messages.Message;
 
 /**
  * WebSocket message handler that parses JSON messages and forwards them to a {@link MessageConsumer}.
+ * @deprecated Please migrate to org.eclipse.lsp4j.websocket.jakarta
  */
+@Deprecated(forRemoval = true)
 public class WebSocketMessageHandler implements MessageHandler.Whole<String> {
 	
 	private final MessageConsumer callback;

--- a/releng/lsp4j-feature/feature.xml
+++ b/releng/lsp4j-feature/feature.xml
@@ -119,18 +119,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.lsp4j.websocket"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.lsp4j.websocket.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/releng/p2/category.xml
+++ b/releng/p2/category.xml
@@ -11,6 +11,7 @@
 	<bundle id="jakarta.websocket-api.source" version="0.0.0"/>
 	<bundle id="jakarta.websocket-client-api" version="0.0.0"/>
 	<bundle id="jakarta.websocket-client-api.source" version="0.0.0"/>
+	<!-- The use of javax.websocket is deprecated for deletion. See https://github.com/eclipse-lsp4j/lsp4j/issues/647 -->
 	<bundle id="javax.websocket" version="0.0.0"/>
 	<bundle id="javax.websocket.source" version="0.0.0"/>
    <category-def name="lsp4j" label="Lsp4j"/>

--- a/releng/releng-target/lsp4j.target.target
+++ b/releng/releng-target/lsp4j.target.target
@@ -15,6 +15,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-03"/>
+			<!-- The use of javax.websocket is deprecated for deletion. See https://github.com/eclipse-lsp4j/lsp4j/issues/647 -->
 			<unit id="javax.websocket" version="0.0.0"/>
 			<unit id="javax.websocket.source" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
The bundle has been annotated deprecated for removal in a future version.

The bundle will not be part of the SDK feature, nor part of SimRel going forward.

Part of #647