### PR TITLE
Unwrap InvocationTargetException which are ResponseErrorException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixed issues: <https://github.com/eclipse-lsp4j/lsp4j/milestone/34?closed=1>
 
   * The exception handling around throwing `ResponseErrorException` has been improved to ensure that it is unwrapped to the expected `ResponseError` on the receiving side.
+  In addition, `@JsonDelegate`s that throw exceptions have their checked exceptions wrapped in the more narrow `IllegalStateException` instead of a `RuntimeException`.
     * See [#802](https://github.com/eclipse-lsp4j/lsp4j/issues/802) for detailed discussion.
 
 Breaking API changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Fixed issues: <https://github.com/eclipse-lsp4j/lsp4j/milestone/34?closed=1>
 
+  * The exception handling around throwing `ResponseErrorException` has been improved to ensure that it is unwrapped to the expected `ResponseError` on the receiving side.
+    * See [#802](https://github.com/eclipse-lsp4j/lsp4j/issues/802) for detailed discussion.
+
 Breaking API changes:
 
 Nightly japicmp report: <https://download.eclipse.org/lsp4j/builds/main/japicmp-report/>

--- a/documentation/jsonrpc.md
+++ b/documentation/jsonrpc.md
@@ -37,7 +37,7 @@ For the other direction, if the implementation calls request on the RemoteEndpoi
 
 The receiver of a request always needs to return a response message to conform to the JSON-RPC specification. In case the result value cannot be provided in a response because of an error, the `error` property of the `ResponseMessage` must be set to a `ResponseError` describing the failure.
 
-This can be done by returning a `CompletableFuture` completed exceptionally with a `ResponseErrorException` from the request message handler in a local endpoint. The exception carries a `ResponseError` to attach to the response. The `RemoteEndpoint` will handle the exceptionally completed future and send a response message with the attached error object.
+This can be done by throwing a `ResponseErrorException` from the request message handler in a local endpoint. The exception carries a `ResponseError` to attach to the response. The `RemoteEndpoint` will handle the exception and send a response message with the attached error object.
 
 For example:
 
@@ -45,10 +45,8 @@ For example:
    @Override
    public CompletableFuture<Object> shutdown() {
       if (!isInitialized()) {
-         CompletableFuture<Object> exceptionalResult = new CompletableFuture<>();
-         ResponseError error = new ResponseError(ResponseErrorCode.ServerNotInitialized, "Server was not initialized", null);
-         exceptionalResult.completeExceptionally(new ResponseErrorException(error));
-         return exceptionalResult;
+         ResponseError error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Server was not initialized", null);
+         throw new ResponseErrorException(error);
       }
       return doShutdown();
    }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016 TypeFox and others.
+ * Copyright (c) 2016, 2024 TypeFox and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,8 +64,10 @@ public class GenericEndpoint implements Endpoint {
 					Method method = methodInfo.method;
 					Object[] arguments = this.getArguments(method, arg);
 					return (CompletableFuture<Object>) method.invoke(current, arguments);
-				} catch (InvocationTargetException | IllegalAccessException e) {
-					throw new RuntimeException(e);
+				} catch (InvocationTargetException e) {
+					throw new CompletionException(e.getCause());
+				} catch (IllegalAccessException e) {
+					throw new CompletionException(e);
 				}
 			};
 			if (methodHandlers.put(methodInfo.name, handler) != null) {

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -83,7 +83,7 @@ public class GenericEndpoint implements Endpoint {
 					LOG.fine("A delegate object is null, jsonrpc methods of '" + method + "' are ignored");
 				}
 			} catch (InvocationTargetException | IllegalAccessException e) {
-				throw new RuntimeException(e);
+				throw new IllegalStateException("An exception occurred while executing JsonDelegate method " + method, e);
 			}
 		});
 	}


### PR DESCRIPTION
By wrapping ResponseErrorException with another layer in RuntimeException it means the unwrapping of the exception in RemoteEndpoint.DEFAULT_EXCEPTION_HANDLER doesn't work as expected and instead of getting the original ResponseError the other end gets the fallback ResponseError of type internal error.

This change includes updates to documentation to show that it is ok to throw ResponseErrorException (reverts https://github.com/eclipse-lsp4j/lsp4j/pull/578). While it is also OK to return an exceptionally completed future, it is not needed to do that way and simply throwing is more straightforward.

There are new tests to cover the changed handling. Also tested is the previously documented way of handling exceptions (see `tries == 1` case in `testVersatility` and `testVersatilityResponseError`

Fixes https://github.com/eclipse-lsp4j/lsp4j/issues/802