### PR TITLE
Fix frameId type in DataBreakpointInfoArguments

### DIFF
--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -1289,6 +1289,8 @@ class DataBreakpointInfoArguments {
 	 * If not specified, the expression is evaluated in the global scope. When
 	 * `variablesReference` is specified, this property has no effect.
 	 * <p>
+     * This is an optional property.
+	 * <p>
 	 * Since 1.59
 	 */
 	Integer frameId;

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -1291,7 +1291,7 @@ class DataBreakpointInfoArguments {
 	 * <p>
 	 * Since 1.59
 	 */
-	int frameId;
+	Integer frameId;
 	/**
 	 * The mode of the desired breakpoint. If defined, this must be one of the `breakpointModes`
 	 * the debug adapter advertised in its `Capabilities`.

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -1289,7 +1289,7 @@ class DataBreakpointInfoArguments {
 	 * If not specified, the expression is evaluated in the global scope. When
 	 * `variablesReference` is specified, this property has no effect.
 	 * <p>
-     * This is an optional property.
+	 * This is an optional property.
 	 * <p>
 	 * Since 1.59
 	 */


### PR DESCRIPTION
According to [spec](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_DataBreakpointInfo) `frameId` in `DataBreakpointInfoArguments` should be optional.