### PR TITLE
Support inactive regions

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -2240,6 +2240,8 @@ class TextDocumentClientCapabilities {
 	 * Since 3.17.0
 	 */
 	DiagnosticCapabilities diagnostic
+	
+	InactiveRegionsCapabilities inactiveRegionsCapabilities
 
 	new() {
 	}
@@ -9953,6 +9955,46 @@ class InlineValueWorkspaceCapabilities {
 
 	new(Boolean refreshSupport) {
 		this.refreshSupport = refreshSupport
+	}
+}
+
+/**
+ * Capabilities specific to the `textDocument/inactiveRegionsCapabilities` notification.
+ */
+@JsonRpcData
+class InactiveRegionsCapabilities {
+
+	Boolean inactiveRegions
+
+	new() {
+	}
+
+	new(Boolean inactiveRegions) {
+		this.inactiveRegions = inactiveRegions
+	}
+}
+
+@JsonRpcData
+class InactiveRegionsParams {
+	/**
+	 * The document for which inactive regions information is reported.
+	 */
+	@NonNull
+	TextDocumentIdentifier textDocument
+
+	/**
+	 * An array of ranges information items.
+	 */
+	@NonNull
+	List<Range> regions
+
+	new() {
+		this.regions = new ArrayList
+	}
+
+	new(@NonNull VersionedTextDocumentIdentifier textDocument, @NonNull List<Range> regions) {
+		this.textDocument = Preconditions.checkNotNull(textDocument, 'textDocument')
+		this.regions = Preconditions.checkNotNull(regions, 'regions')
 	}
 }
 


### PR DESCRIPTION
this feature is needed for a clangd protocol extension. See this cdt-lsp issue https://github.com/eclipse-cdt/cdt-lsp/issues/299 and this clangd commit: https://reviews.llvm.org/D143974 It is needed for macro enable in the C/C++ language