### PR TITLE
Unsupported Operation Exception in Language Servers - Fixes #853

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageServer.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageServer.java
@@ -122,6 +122,9 @@ public interface LanguageServer {
 	 */
 	@JsonNotification("$/setTrace")
 	default void setTrace(SetTraceParams params) {
-		throw new UnsupportedOperationException();
+		/**
+		 * The method default behaviour was to throw UnsupportedOperationException
+		 * Keeping as empty to avoid it.
+		 */
 	}
 }


### PR DESCRIPTION
Updated the method `setTrace()` as empty in the interface `LanguageServer`.

Fixes #853 