### PR TITLE
Fix minor typos and clarify non-blocking handler guidance

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -43,6 +43,8 @@ This will start the listening process in a new thread that reads messages from t
 
 When implementing the handlers for requests or notifications, you need to be aware that the calling thread is the thread that reads and dispatches incoming messages. Therefore, blocking it may result in reduced throughput or even a deadlock (https://github.com/eclipse-lsp4j/lsp4j/issues/775). As a general rule, message handlers should be implemented in a non-blocking, asynchronous way.
 
+For long-running work, prefer returning a `CompletableFuture` and performing the actual computation outside of the message dispatching thread. This keeps the JSON-RPC message processor responsive while the request is being handled asynchronously.
+
 To stop listening for incoming messages, call `future.cancel(true)` (https://github.com/eclipse-lsp4j/lsp4j/issues/770).
 
 # Extending the Protocol

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java
@@ -197,7 +197,7 @@ public class RemoteEndpoint implements Endpoint, MessageConsumer, MessageIssueHa
 			final var responseMessage = (ResponseMessage) message;
 			handleResponse(responseMessage);
 		} else {
-			LOG.log(Level.WARNING, "Unkown message type.", message);
+			LOG.log(Level.WARNING, "Unknown message type.", message);
 		}
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
@@ -11,12 +11,6 @@
  ******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc;
 
-import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
-import org.eclipse.lsp4j.jsonrpc.messages.Message;
-import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
-import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
-import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
-
 import java.io.PrintWriter;
 import java.time.Clock;
 import java.time.Instant;
@@ -24,9 +18,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.WARNING;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
 
 /**
  * A {@link MessageConsumer} that outputs logs in a format that can be parsed by the LSP Inspector.
@@ -65,7 +64,7 @@ public class TracingMessageConsumer implements MessageConsumer {
 	 * @param receivedRequests A map that keeps track of pending received request data.
 	 * @param printWriter Where to write the log to.
 	 * @param clock The clock that is used to calculate timestamps and durations.
-	 * @param locale THe Locale to format the timestamps and durations, or <code>null</code> to use default locale.
+	 * @param locale The Locale to format the timestamps and durations, or <code>null</code> to use default locale.
 	 */
 	public TracingMessageConsumer(
 			MessageConsumer messageConsumer,


### PR DESCRIPTION
Summary

This PR includes three small documentation and cleanup changes:

Fixes a typo in the warning message for unknown message types in RemoteEndpoint.
Fixes a typo in the Javadoc of TracingMessageConsumer.
Clarifies the recommendation for request and notification handlers to avoid blocking the message dispatching thread.

Motivation

These changes are minor, but they improve readability and documentation clarity. The added note in the documentation makes the existing recommendation about non-blocking handlers more explicit by suggesting the use of CompletableFuture for long-running work.

Impact

This PR does not change runtime behavior or public APIs. The changes are limited to a log message typo, Javadoc text, and documentation.