### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,49 +1,36 @@
-<!--- https://www.eclipse.org/security/ --->
-_ISO 27005 defines vulnerability as:
- "A weakness of an asset or group of assets that can be exploited by one or more threats."_
+# Security Policy
 
-## The Eclipse Security Team
+This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
 
-The Eclipse Security Team provides help and advice to Eclipse projects
-on vulnerability issues and is the first point of contact
-for handling security vulnerabilities.
-Members of the Security Team are committers on Eclipse Projects
-and members of the Eclipse Architecture Council.
+## How To Report a Vulnerability
 
-Contact the [Eclipse Security Team](mailto:security@eclipse.org).
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
 
-**Note that, as a matter of policy, the security team does not open attachments.**
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
 
-## Reporting a Security Vulnerability
+Instead, report it using one of the following ways:
 
-Vulnerabilities can be reported either via email to the Eclipse Security Team
-or directly with a project via the Eclipse Foundation's Bugzilla instance.
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* Report a [vulnerability](https://github.com/eclipse-lsp4j/lsp4j/security/advisories/new) directly via private vulnerability reporting on GitHub
 
-The general security mailing list address is security@eclipse.org.
-Members of the Eclipse Security Team will receive messages sent to this address.
-This address should be used only for reporting undisclosed vulnerabilities;
-regular issue reports and questions unrelated to vulnerabilities in Eclipse software
-will be ignored.
-Note that this email address is not encrypted.
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 
-The community is also encouraged to report vulnerabilities using the
-[Eclipse Foundation's Bugzilla instance](https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Community&component=Vulnerability%20Reports&keywords=security&groups=Security_Advisories).
-Note that you will require an Eclipse Foundation account to create an issue report,
-but by doing so you will be able to participate directly in the resolution of the issue.
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
-Issue reports related to vulnerabilities must be marked as "committers-only",
-either automatically by clicking the provided link, by the reporter,
-or by a committer during the triage process.
-Note that issues marked "committers-only" are visible to all Eclipse committers.
-By default, a "committers-only" issue is also accessible to the reporter
-and individuals explicitly indicated in the "cc" list.
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
 
-## Disclosure
+This information will help us triage your report more quickly.
 
-Disclosure is initially limited to the reporter and all Eclipse Committers,
-but is expanded to include other individuals, and the general public.
-The timing and manner of disclosure is governed by the
-[Eclipse Security Policy](https://www.eclipse.org/security/policy.php).
+## Supported Versions
 
-Publicly disclosed issues are listed on the
-[Disclosed Vulnerabilities Page](https://www.eclipse.org/security/known.php).
+Supported versions are:
+
+* [The latest version](https://github.com/eclipse-lsp4j/lsp4j/releases/latest)


### PR DESCRIPTION
Updates SECURITY.md to match the current version of the Eclipse Foundation template for this file:
https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md