### PR TITLE
Refactor range and position utility methods for readability

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Positions.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Positions.java
@@ -26,16 +26,18 @@ public final class Positions {
 	 * If you want to allow equality, use {@link Position#equals}.
 	 */
 	public static boolean isBefore(Position left, Position right) {
-		Preconditions.checkNotNull(left, "left");
-		Preconditions.checkNotNull(right, "right");
-		if (left.getLine() < right.getLine()) {
-			return true;
-		}
-		if (left.getLine() > right.getLine()) {
-			return false;
-		}
-		return left.getCharacter() < right.getCharacter();
-	}
+    Preconditions.checkNotNull(left, "left");
+    Preconditions.checkNotNull(right, "right");
+
+    int leftLine = left.getLine();
+    int rightLine = right.getLine();
+
+    if (leftLine != rightLine) {
+        return leftLine < rightLine;
+    }
+
+    return left.getCharacter() < right.getCharacter();
+}
 
 	private Positions() {
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Ranges.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Ranges.java
@@ -25,21 +25,32 @@ public final class Ranges {
 	 * the {@code bigger} range. Otherwise, {@code false}.
 	 */
 	public static boolean containsRange(Range bigger, Range smaller) {
-		Preconditions.checkNotNull(bigger, "bigger");
-		Preconditions.checkNotNull(smaller, "smaller");
-		return containsPosition(bigger, smaller.getStart()) && containsPosition(bigger, smaller.getEnd());
-	}
+    Preconditions.checkNotNull(bigger, "bigger");
+    Preconditions.checkNotNull(smaller, "smaller");
+
+    Position smallerStart = smaller.getStart();
+    Position smallerEnd = smaller.getEnd();
+
+    return containsPosition(bigger, smallerStart) && containsPosition(bigger, smallerEnd);
+}
 
 	/**
 	 * {@code true} if the {@link Position position} is either inside or on the
 	 * border of the {@link Range range}. Otherwise, {@code false}.
 	 */
 	public static boolean containsPosition(Range range, Position position) {
-		Preconditions.checkNotNull(range, "range");
-		Preconditions.checkNotNull(position, "position");
-		return range.getStart().equals(position) || Positions.isBefore(range.getStart(), position)
-				&& (range.getEnd().equals(position) || Positions.isBefore(position, range.getEnd()));
-	}
+    Preconditions.checkNotNull(range, "range");
+    Preconditions.checkNotNull(position, "position");
+
+    Position start = range.getStart();
+    Position end = range.getEnd();
+
+    boolean startsAtPosition = start.equals(position);
+    boolean isAfterStart = Positions.isBefore(start, position);
+    boolean endsAtOrAfterPosition = end.equals(position) || Positions.isBefore(position, end);
+
+    return startsAtPosition || (isAfterStart && endsAtOrAfterPosition);
+}
 
 	private Ranges() {
 


### PR DESCRIPTION
Hi LSP4J maintainers,

This PR refactors three small utility methods in Positions and Ranges to improve readability without changing behavior or public APIs.

The changes are intentionally small and limited, as to not affect the perfomance of the project.

simplifying the conditional flow in Positions.isBefore;
introducing local variables in Ranges.containsRange;
splitting the boolean expression in Ranges.containsPosition into clearer intermediate variables.

The method signatures, inputs, outputs, and expected behavior remain unchanged. The goal is only to make the utility logic easier to read and maintain.

I also kept the change limited to existing Java utility classes and avoided any API-level changes.