### PR TITLE
Refactor range and position utility methods for readability

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Positions.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Positions.java
@@ -26,16 +26,18 @@ public final class Positions {
 	 * If you want to allow equality, use {@link Position#equals}.
 	 */
 	public static boolean isBefore(Position left, Position right) {
-		Preconditions.checkNotNull(left, "left");
-		Preconditions.checkNotNull(right, "right");
-		if (left.getLine() < right.getLine()) {
-			return true;
-		}
-		if (left.getLine() > right.getLine()) {
-			return false;
-		}
-		return left.getCharacter() < right.getCharacter();
-	}
+    Preconditions.checkNotNull(left, "left");
+    Preconditions.checkNotNull(right, "right");
+
+    int leftLine = left.getLine();
+    int rightLine = right.getLine();
+
+    if (leftLine != rightLine) {
+        return leftLine < rightLine;
+    }
+
+    return left.getCharacter() < right.getCharacter();
+}
 
 	private Positions() {
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Ranges.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/util/Ranges.java
@@ -25,21 +25,32 @@ public final class Ranges {
 	 * the {@code bigger} range. Otherwise, {@code false}.
 	 */
 	public static boolean containsRange(Range bigger, Range smaller) {
-		Preconditions.checkNotNull(bigger, "bigger");
-		Preconditions.checkNotNull(smaller, "smaller");
-		return containsPosition(bigger, smaller.getStart()) && containsPosition(bigger, smaller.getEnd());
-	}
+    Preconditions.checkNotNull(bigger, "bigger");
+    Preconditions.checkNotNull(smaller, "smaller");
+
+    Position smallerStart = smaller.getStart();
+    Position smallerEnd = smaller.getEnd();
+
+    return containsPosition(bigger, smallerStart) && containsPosition(bigger, smallerEnd);
+}
 
 	/**
 	 * {@code true} if the {@link Position position} is either inside or on the
 	 * border of the {@link Range range}. Otherwise, {@code false}.
 	 */
 	public static boolean containsPosition(Range range, Position position) {
-		Preconditions.checkNotNull(range, "range");
-		Preconditions.checkNotNull(position, "position");
-		return range.getStart().equals(position) || Positions.isBefore(range.getStart(), position)
-				&& (range.getEnd().equals(position) || Positions.isBefore(position, range.getEnd()));
-	}
+    Preconditions.checkNotNull(range, "range");
+    Preconditions.checkNotNull(position, "position");
+
+    Position start = range.getStart();
+    Position end = range.getEnd();
+
+    boolean startsAtPosition = start.equals(position);
+    boolean isAfterStart = Positions.isBefore(start, position);
+    boolean endsAtOrAfterPosition = end.equals(position) || Positions.isBefore(position, end);
+
+    return startsAtPosition || (isAfterStart && endsAtOrAfterPosition);
+}
 
 	private Ranges() {
 


### PR DESCRIPTION
Hi LSP4J maintainers,

This PR refactors three small utility methods in Positions and Ranges to improve readability without changing behavior or public APIs.

The changes made are small and limited so as not to impact the functionality of the project.

The changes are limited to a few utility methods: `Positions.isBefore`, `Ranges.containsRange`, and `Ranges.containsPosition`. I simplified the condition in `Positions.isBefore`, added local variables in `Ranges.containsRange`, and broke down the boolean expression in `Ranges.containsPosition` so the logic of the method is a bit easier to follow.

The inputs, expected return values, and expected behavior have not been altered. These changes do not introduce any API-level changes.
