### PR TITLE
Fix element type adapter in `InlineValueResponseAdapter`

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/InlineValueResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/InlineValueResponseAdapter.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 
 import org.eclipse.lsp4j.InlineValue;
 import org.eclipse.lsp4j.InlineValueEvaluatableExpression;
+import org.eclipse.lsp4j.InlineValueText;
 import org.eclipse.lsp4j.InlineValueVariableLookup;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.CollectionTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
@@ -40,7 +41,21 @@ public class InlineValueResponseAdapter implements TypeAdapterFactory {
 		final var secondChecker = new PropertyChecker("caseSensitiveLookup");
 		final var thirdChecker = new PropertyChecker("range");
 		final var elementTypeAdapter = new EitherTypeAdapter<>(gson, ELEMENT_TYPE, firstChecker, secondChecker.or(thirdChecker),
-						null, new EitherTypeAdapter<>(gson, R_ELEMENT_TYPE, secondChecker, thirdChecker));
+						null, new EitherTypeAdapter<>(gson, R_ELEMENT_TYPE, secondChecker, thirdChecker)) {
+
+			@Override
+			protected InlineValue createLeft(InlineValueText obj) {
+				return new InlineValue(obj);
+			}
+
+			@Override
+			protected InlineValue createRight(Either<InlineValueVariableLookup, InlineValueEvaluatableExpression> obj) {
+				if (obj.isLeft()) {
+					return new InlineValue(obj.getLeft());
+				}
+				return new InlineValue(obj.getRight());
+			}
+		};
 		return (TypeAdapter<T>) new CollectionTypeAdapter<>(gson, ELEMENT_TYPE.getType(), elementTypeAdapter, ArrayList::new);
 	}
 }

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -49,6 +49,7 @@ import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.HoverCapabilities
 import org.eclipse.lsp4j.ImplementationCapabilities
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InlineValue
 import org.eclipse.lsp4j.InlineValueEvaluatableExpression
 import org.eclipse.lsp4j.InlineValueText
 import org.eclipse.lsp4j.InlineValueVariableLookup
@@ -1827,7 +1828,7 @@ class JsonParseTest {
 		'''.assertParse(new ResponseMessage => [
 			jsonrpc = "2.0"
 			id = "12"
-			result = newArrayList(Either3.forFirst(
+			result = newArrayList(new InlineValue(
 				new InlineValueText => [
 					range = new Range => [
 						start = new Position(4, 22)
@@ -1869,7 +1870,7 @@ class JsonParseTest {
 		'''.assertParse(new ResponseMessage => [
 			jsonrpc = "2.0"
 			id = "12"
-			result = newArrayList(Either3.forSecond(
+			result = newArrayList(new InlineValue(
 				new InlineValueVariableLookup => [
 					range = new Range => [
 						start = new Position(4, 22)
@@ -1910,7 +1911,7 @@ class JsonParseTest {
 		'''.assertParse(new ResponseMessage => [
 			jsonrpc = "2.0"
 			id = "12"
-			result = newArrayList(Either3.forThird(
+			result = newArrayList(new InlineValue(
 				new InlineValueEvaluatableExpression => [
 					range = new Range => [
 						start = new Position(4, 22)

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
@@ -41,6 +41,10 @@ import org.eclipse.lsp4j.HoverCapabilities
 import org.eclipse.lsp4j.ImplementationCapabilities
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializeResult
+import org.eclipse.lsp4j.InlineValue
+import org.eclipse.lsp4j.InlineValueEvaluatableExpression
+import org.eclipse.lsp4j.InlineValueText
+import org.eclipse.lsp4j.InlineValueVariableLookup
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.MarkupKind
 import org.eclipse.lsp4j.OnTypeFormattingCapabilities
@@ -959,4 +963,116 @@ class JsonSerializeTest {
 		''')
 	}
 	
+
+	@Test
+	def void testInlineValueResponse1() {
+		val message = new ResponseMessage => [
+			jsonrpc = "2.0"
+			id = "12"
+			result = newArrayList(new InlineValue(
+				new InlineValueText => [
+					range = new Range => [
+						start = new Position(4, 22)
+						end = new Position(4, 25)
+					]
+					text = "foo"
+				]
+			))
+		]
+		message.assertSerialize('''
+			{
+			  "jsonrpc": "2.0",
+			  "id": "12",
+			  "result": [
+			    {
+			      "range": {
+			        "start": {
+			          "line": 4,
+			          "character": 22
+			        },
+			        "end": {
+			          "line": 4,
+			          "character": 25
+			        }
+			      },
+			      "text": "foo"
+			    }
+			  ]
+			}
+		''')
+	}
+
+	@Test
+	def void testInlineValueResponse2() {
+		val message = new ResponseMessage => [
+			jsonrpc = "2.0"
+			id = "12"
+			result = newArrayList(new InlineValue(
+				new InlineValueVariableLookup => [
+					range = new Range => [
+						start = new Position(4, 22)
+						end = new Position(4, 25)
+					]
+					caseSensitiveLookup = false
+				]
+			))
+		]
+		message.assertSerialize('''
+			{
+			  "jsonrpc": "2.0",
+			  "id": "12",
+			  "result": [
+			    {
+			      "range": {
+			        "start": {
+			          "line": 4,
+			          "character": 22
+			        },
+			        "end": {
+			          "line": 4,
+			          "character": 25
+			        }
+			      },
+			      "caseSensitiveLookup": false
+			    }
+			  ]
+			}
+		''')
+	}
+
+	@Test
+	def void testInlineValueResponse3() {
+		val message = new ResponseMessage => [
+			jsonrpc = "2.0"
+			id = "12"
+			result = newArrayList(new InlineValue(
+				new InlineValueEvaluatableExpression => [
+					range = new Range => [
+						start = new Position(4, 22)
+						end = new Position(4, 25)
+					]
+				]
+			))
+		]
+		message.assertSerialize('''
+			{
+			  "jsonrpc": "2.0",
+			  "id": "12",
+			  "result": [
+			    {
+			      "range": {
+			        "start": {
+			          "line": 4,
+			          "character": 22
+			        },
+			        "end": {
+			          "line": 4,
+			          "character": 25
+			        }
+			      }
+			    }
+			  ]
+			}
+		''')
+	}
 }


### PR DESCRIPTION
* Fixes element type adapter in `InlineValueResponseAdapter` so that it properly creates instances of `InlineValue` rather than `Either3`

* Fixes `testInlineValueResponseN` methods in `JsonParseTest` so that they properly expect instances of `InlineValue` rather than `Either3`

* Adds `testInlineValueResponseN` methods to `JsonSerializeTest`

Fixes #866.